### PR TITLE
go mod & parsing bugfix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/falafeljan/tmls
+
+go 1.12
+
+require github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942 h1:A7GG7zcGjl3jqAqGPmcNjd/D9hzL95SuoOQAaFNdLU0=
+github.com/pkg/term v0.0.0-20190109203006-aa71e9d9e942/go.mod h1:eCbImbZ95eXtAUIbLAuAVnBnwf83mjf6QIVH8SHYwqQ=

--- a/select.go
+++ b/select.go
@@ -49,6 +49,11 @@ func displaySessions(sessions []Session, selected int, length int) {
 }
 
 func selectItem(sessions []Session) *Session {
+	if len(sessions) == 0 {
+		fmt.Printf("There are no active tmux sessions.\n")
+		return nil
+	}
+
 	selected := 0
 
 	cursorHide()

--- a/tmux.go
+++ b/tmux.go
@@ -17,7 +17,7 @@ type Session struct {
 }
 
 func compilePattern() (*regexp.Regexp, error) {
-	return regexp.Compile(`^([^:]+)\: (\d+) windows \(.*\) \[(\d+)x(\d+)\](\s\(attached\))?`)
+	return regexp.Compile(`^([^:]+)\: (\d+) windows \([^\(]*\)(\s\[(\d+)x(\d+)\])?(\s\(attached\))?`)
 }
 
 func getTmuxSessions() []string {
@@ -48,20 +48,22 @@ func parseSessions(sessionEntries []string, r *regexp.Regexp) []Session {
 
 		match := res[0]
 
-		if len(match) < 5 {
+		if len(match) < 3 {
 			continue
 		}
 
 		windows, err := strconv.Atoi(match[2])
+		attachedValue := match[len(match) - 1]
+		attached := attachedValue == " (attached)"
 
 		if err != nil {
 			continue
 		}
-
+		
 		sessions = append(sessions, Session{
 			name:     match[1],
 			windows:  windows,
-			attached: len(match) > 5 && match[5] != ""})
+			attached: attached})
 	}
 
 	return sessions
@@ -71,7 +73,7 @@ func getSessions() []Session {
 	r, err := compilePattern()
 
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "There is an error with our expression: ", err)
+		fmt.Fprintln(os.Stderr, "There is an error with our regular expression: ", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
add go modules configuration. also, fix a bug that occured when the shell size (e.g., "[200x50]") has been ommited in the `tmux ls` output.